### PR TITLE
Data Exports

### DIFF
--- a/src/integration/java/com/orgsync/api/integration/BaseIntegrationTest.java
+++ b/src/integration/java/com/orgsync/api/integration/BaseIntegrationTest.java
@@ -15,22 +15,21 @@
 */
 package com.orgsync.api.integration;
 
-import static org.junit.Assert.assertThat;
+import com.orgsync.api.ApiClient;
+import com.orgsync.api.ApiResponse;
+import com.orgsync.api.OrgSync;
+import com.orgsync.api.Resource;
+import com.typesafe.config.Config;
+import org.hamcrest.core.IsCollectionContaining;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
-import org.hamcrest.core.IsCollectionContaining;
-
-import com.ning.http.client.ListenableFuture;
-import com.orgsync.api.ApiClient;
-import com.orgsync.api.ApiResponse;
-import com.orgsync.api.OrgSync;
-import com.orgsync.api.Resource;
-import com.typesafe.config.Config;
+import static org.junit.Assert.assertThat;
 
 public class BaseIntegrationTest<T> {
 
@@ -51,7 +50,7 @@ public class BaseIntegrationTest<T> {
         return resource;
     }
 
-    public <R> R getResult(final ListenableFuture<ApiResponse<R>> future) throws InterruptedException,
+    public <R> R getResult(final Future<ApiResponse<R>> future) throws InterruptedException,
             ExecutionException {
         return future.get().getResult();
     }

--- a/src/integration/java/com/orgsync/api/integration/BaseIntegrationTest.java
+++ b/src/integration/java/com/orgsync/api/integration/BaseIntegrationTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -35,10 +36,13 @@ public class BaseIntegrationTest<T> {
 
     public static final String API_KEY = DbTemplate.getString("api_key");
     public static final String HOST = "http://localhost:8080/api/v2";
+    private static final Properties PROPS = new Properties() {{
+        put("exports.poll_interval", "1000");
+    }};
 
     private static final Map<Resource<?>, ApiClient> clients = new HashMap<Resource<?>, ApiClient>();
 
-    final ApiClient client = OrgSync.newApiClient(API_KEY, HOST);
+    final ApiClient client = OrgSync.newApiClient(API_KEY, HOST, PROPS);
     private final T resource;
 
     public BaseIntegrationTest(final Resource<T> resourceKey) {

--- a/src/integration/java/com/orgsync/api/integration/ExportsIntegrationTest.java
+++ b/src/integration/java/com/orgsync/api/integration/ExportsIntegrationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014 OrgSync
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.orgsync.api.integration;
+
+import com.orgsync.api.ExportsResource;
+import com.orgsync.api.Resource;
+import com.orgsync.api.Resources;
+import com.orgsync.api.model.accounts.AccountFull;
+import com.orgsync.api.model.orgs.OrgFull;
+import com.orgsync.api.model.timesheets.Timesheet;
+import com.typesafe.config.Config;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * @author steffyj
+ */
+public class ExportsIntegrationTest extends BaseIntegrationTest<ExportsResource> {
+
+    public ExportsIntegrationTest() {
+        super(Resources.EXPORTS);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        BaseIntegrationTest.cleanup(Resources.EXPORTS);
+    }
+
+    @Test
+    public void testGetAccounts() throws Exception {
+        List<? extends Config> configAccounts = DbTemplate.getList("users");
+        List<AccountFull> accounts = getResult(getResource().getAccounts());
+        testContainsIds(accounts, configAccounts);
+    }
+
+    @Test
+    public void testGetOrgs() throws Exception {
+        List<? extends Config> configPortals = DbTemplate.getList("portals");
+        List<OrgFull> orgs = getResult(getResource().getOrgs());
+        testContainsIds(orgs, configPortals);
+    }
+
+    @Test
+    public void testGetTimesheets() throws Exception {
+        List<? extends Config> configTimesheets = DbTemplate.getList("timesheets");
+        List<Timesheet> timesheets = getResult(getResource().getTimesheets());
+        testContainsIds(timesheets, configTimesheets);
+    }
+}

--- a/src/main/java/com/orgsync/api/ApiClientImpl.java
+++ b/src/main/java/com/orgsync/api/ApiClientImpl.java
@@ -190,15 +190,16 @@ import com.orgsync.api.model.ApiError;
         @SuppressWarnings("unchecked")
         public T onCompleted(final Response response) throws Exception {
             String body = response.getResponseBody();
-            log.debug("Received response string: {}", body);
+            int status = response.getStatusCode();
+            log.debug("Received response with status={}, body={}", status, body);
 
-            if (response.getStatusCode() == 200) {
+            if (status >= 200 && status < 300) {
                 return (T) ApiResponseFactory
-                        .success(JsonSerializer.fromJson(body, type));
+                        .success(status, JsonSerializer.fromJson(body, type));
             }
 
             return (T) ApiResponseFactory
-                        .error(JsonSerializer.fromJson(body, ApiError.class));
+                        .error(status, JsonSerializer.fromJson(body, ApiError.class));
         }
 
     }

--- a/src/main/java/com/orgsync/api/ApiClientImpl.java
+++ b/src/main/java/com/orgsync/api/ApiClientImpl.java
@@ -17,6 +17,7 @@ package com.orgsync.api;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,12 +52,14 @@ import com.orgsync.api.model.ApiError;
     private final String apiKey;
 
     private final String host;
+    private final Properties props;
 
     private AsyncHttpClient client;
 
-    /* package */ApiClientImpl(final String apiKey, final String host) {
+    /* package */ApiClientImpl(final String apiKey, final String host, final Properties props) {
         this.host = host;
         this.apiKey = apiKey;
+        this.props = props;
         setHttpClient(new AsyncHttpClient());
     }
 
@@ -80,6 +83,10 @@ import com.orgsync.api.model.ApiError;
     @Override
     public AsyncHttpClient getHttpClient() {
         return client;
+    }
+    
+    /* package */Properties getProps() {
+        return props;
     }
 
     @Override

--- a/src/main/java/com/orgsync/api/ApiResponse.java
+++ b/src/main/java/com/orgsync/api/ApiResponse.java
@@ -31,6 +31,13 @@ import com.orgsync.api.model.ApiError;
 public interface ApiResponse<T> {
 
     /**
+     * Get the status code that was returned from this request.
+     *
+     * @return the status code
+     */
+    public int getStatus();
+
+    /**
      * Return whether this response is a success or not. The {@link #getResult()} method only returns a value if this is
      * <code>true</code>.
      * 

--- a/src/main/java/com/orgsync/api/ApiResponseFactory.java
+++ b/src/main/java/com/orgsync/api/ApiResponseFactory.java
@@ -166,7 +166,6 @@ import com.orgsync.api.model.ApiError;
             try {
                 response = ApiResponseFactory.success(getStatus(), f.f(getResult()));
             } catch (Exception e) {
-                e.printStackTrace();
                 response = ApiResponseFactory.error(500, "Exception caught: " + e.getMessage());
             }
 
@@ -178,7 +177,6 @@ import com.orgsync.api.model.ApiError;
             try {
                 return f.f(getResult());
             } catch (Exception e) {
-                e.printStackTrace();
                 return ApiResponseFactory.error(500, "Exception caught: " + e.getMessage());
             }
         }

--- a/src/main/java/com/orgsync/api/ApiResponseFactory.java
+++ b/src/main/java/com/orgsync/api/ApiResponseFactory.java
@@ -81,6 +81,22 @@ import com.orgsync.api.model.ApiError;
             return status;
         }
 
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof BaseResponse)) return false;
+
+            BaseResponse that = (BaseResponse) o;
+
+            if (status != that.status) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return status;
+        }
     }
 
     private static final class FailureResponse<T> extends BaseResponse implements ApiResponse<T> {
@@ -110,6 +126,7 @@ import com.orgsync.api.model.ApiError;
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof FailureResponse)) return false;
+            if (!super.equals(o)) return false;
 
             FailureResponse that = (FailureResponse) o;
 
@@ -120,7 +137,9 @@ import com.orgsync.api.model.ApiError;
 
         @Override
         public int hashCode() {
-            return error.hashCode();
+            int result = super.hashCode();
+            result = 31 * result + error.hashCode();
+            return result;
         }
     }
 

--- a/src/main/java/com/orgsync/api/ApiResponseFactory.java
+++ b/src/main/java/com/orgsync/api/ApiResponseFactory.java
@@ -74,6 +74,22 @@ import com.orgsync.api.model.ApiError;
             return null;
         }
 
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof FailureResponse)) return false;
+
+            FailureResponse that = (FailureResponse) o;
+
+            if (!error.equals(that.error)) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return error.hashCode();
+        }
     }
 
     private static final class SuccessResponse<T> implements ApiResponse<T> {

--- a/src/main/java/com/orgsync/api/ApiResponseFactory.java
+++ b/src/main/java/com/orgsync/api/ApiResponseFactory.java
@@ -130,7 +130,7 @@ import com.orgsync.api.model.ApiError;
 
             FailureResponse that = (FailureResponse) o;
 
-            if (!error.equals(that.error)) return false;
+            if (error != null ? !error.equals(that.error) : that.error != null) return false;
 
             return true;
         }
@@ -138,7 +138,7 @@ import com.orgsync.api.model.ApiError;
         @Override
         public int hashCode() {
             int result = super.hashCode();
-            result = 31 * result + error.hashCode();
+            result = 31 * result + (error != null ? error.hashCode() : 0);
             return result;
         }
     }

--- a/src/main/java/com/orgsync/api/ApiResponseFactory.java
+++ b/src/main/java/com/orgsync/api/ApiResponseFactory.java
@@ -30,11 +30,24 @@ import com.orgsync.api.model.ApiError;
     }
 
     /**
-     * Create an api response of type error.
-     * 
-     * @param error
-     *            the error that was returned.
-     * @return the api response
+     * Create an api response error from an error message.
+     *
+     * @param status The status to return
+     * @param error the error message
+     * @param <T> The type of the expected response
+     * @return The failed api response
+     */
+    /* package */static final <T> BaseApiResponse<T> error(final int status, final String error) {
+        return new FailureResponse<T>(status, new ApiError(error));
+    }
+
+    /**
+     * Create an api response error from an ApiError.
+     *
+     * @param status The status to return
+     * @param error the error to use
+     * @param <T> The type of the expected response
+     * @return The failed api response
      */
     /* package */static final <T> BaseApiResponse<T> error(final int status, final ApiError error) {
         return new FailureResponse<T>(status, error);
@@ -154,7 +167,7 @@ import com.orgsync.api.model.ApiError;
                 response = ApiResponseFactory.success(getStatus(), f.f(getResult()));
             } catch (Exception e) {
                 e.printStackTrace();
-                response = ApiResponseFactory.error(500, new ApiError("Exception caught: " + e.getMessage()));
+                response = ApiResponseFactory.error(500, "Exception caught: " + e.getMessage());
             }
 
             return response;
@@ -166,7 +179,7 @@ import com.orgsync.api.model.ApiError;
                 return f.f(getResult());
             } catch (Exception e) {
                 e.printStackTrace();
-                return ApiResponseFactory.error(500, new ApiError("Exception caught: " + e.getMessage()));
+                return ApiResponseFactory.error(500, "Exception caught: " + e.getMessage());
             }
         }
     }

--- a/src/main/java/com/orgsync/api/BaseApiResponse.java
+++ b/src/main/java/com/orgsync/api/BaseApiResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 OrgSync
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.orgsync.api;
+
+/**
+* @author steffyj
+*/
+/* package */abstract class BaseApiResponse<T> implements ApiResponse<T> {
+
+    private final int status;
+
+    public BaseApiResponse(final int status) {
+        this.status = status;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BaseApiResponse)) return false;
+
+        BaseApiResponse that = (BaseApiResponse) o;
+
+        if (status != that.status) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return status;
+    }
+
+    /* package */abstract <S> BaseApiResponse<S> map(MapFunction<T, S> f);
+
+    /* package */abstract <S> BaseApiResponse<S> flatMap(MapFunction<T, BaseApiResponse<S>> f);
+}

--- a/src/main/java/com/orgsync/api/BaseResource.java
+++ b/src/main/java/com/orgsync/api/BaseResource.java
@@ -67,6 +67,10 @@ import com.orgsync.api.model.forms.FormUpdate;
         this.endpoint = endpoint;
     }
 
+    /* package */ApiClientImpl getClient() {
+        return client;
+    }
+
     /**
      * Get a response for the request params and type... delegate to client.
      * 

--- a/src/main/java/com/orgsync/api/DataExportTask.java
+++ b/src/main/java/com/orgsync/api/DataExportTask.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 OrgSync
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.orgsync.api;
+
+import com.orgsync.api.model.ApiError;
+import com.orgsync.api.model.accounts.AccountFull;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+/**
+ * A task that handles the full life-cycle of getting an export.
+ *
+ * @author steffyj
+ */
+/* package */class DataExportTask<T> implements Callable<ApiResponse<T>> {
+
+    private final ExportsResourceImpl exports;
+    private final String exportType;
+
+    public DataExportTask(ExportsResourceImpl exports, String exportType) {
+        this.exports = exports;
+        this.exportType = exportType;
+    }
+
+    @Override
+    public ApiResponse<T> call() throws Exception {
+        ApiResponse<ExportsResourceImpl.ExportRequest> response = exports.requestToken(exportType).get();
+
+        if (response.isSuccess()) {
+            return ApiResponseFactory.error(new ApiError(response.getResult().getExportToken()));
+        } else {
+            return ApiResponseFactory.error(response.getError());
+        }
+    }
+
+}

--- a/src/main/java/com/orgsync/api/DataExportTask.java
+++ b/src/main/java/com/orgsync/api/DataExportTask.java
@@ -43,6 +43,8 @@ import java.util.concurrent.Future;
 
         if (!response.isSuccess()) {
             return ApiResponseFactory.error(response);
+        } else if (response.getStatus() == 202) {
+            return ApiResponseFactory.error(response.getStatus(), new ApiError("Export already in progress!"));
         }
 
         return ApiResponseFactory.error(response.getStatus(), new ApiError(response.getResult().getExportToken()));

--- a/src/main/java/com/orgsync/api/DataExportTask.java
+++ b/src/main/java/com/orgsync/api/DataExportTask.java
@@ -41,11 +41,11 @@ import java.util.concurrent.Future;
     public ApiResponse<T> call() throws Exception {
         ApiResponse<ExportsResourceImpl.ExportRequest> response = exports.requestToken(exportType).get();
 
-        if (response.isSuccess()) {
-            return ApiResponseFactory.error(new ApiError(response.getResult().getExportToken()));
-        } else {
-            return ApiResponseFactory.error(response.getError());
+        if (!response.isSuccess()) {
+            return ApiResponseFactory.error(response);
         }
+
+        return ApiResponseFactory.error(response.getStatus(), new ApiError(response.getResult().getExportToken()));
     }
 
 }

--- a/src/main/java/com/orgsync/api/DataExportTask.java
+++ b/src/main/java/com/orgsync/api/DataExportTask.java
@@ -55,7 +55,7 @@ import java.util.concurrent.TimeUnit;
         // we don't want to have two futures working on this.
         // return it as a failure
         if (response.getStatus() == 202) {
-            response = ApiResponseFactory.error(response.getStatus(), new ApiError("Export already in progress!"));
+            response = ApiResponseFactory.error(response.getStatus(), "Export already in progress!");
         }
 
         // normal success or fail, return as is.
@@ -73,14 +73,14 @@ import java.util.concurrent.TimeUnit;
         // The 204 - No Content means something went wrong and there is nothing to get
         // This is a success...  but we should make it a failure
         if (response.getStatus() == 204) {
-            response = ApiResponseFactory.error(response.getStatus(), new ApiError("Export has failed!"));
+            response = ApiResponseFactory.error(response.getStatus(), "Export has failed!");
         }
 
         return response;
     }
 
     private BaseApiResponse<T> downloadFile(String url) {
-        return ApiResponseFactory.error(200, new ApiError(url));
+        return ApiResponseFactory.error(200, url);
     }
 
     /**

--- a/src/main/java/com/orgsync/api/ExportsResource.java
+++ b/src/main/java/com/orgsync/api/ExportsResource.java
@@ -16,7 +16,10 @@
 package com.orgsync.api;
 
 import com.orgsync.api.model.accounts.AccountFull;
+import com.orgsync.api.model.orgs.OrgFull;
+import com.orgsync.api.model.timesheets.Timesheet;
 
+import java.sql.Time;
 import java.util.List;
 import java.util.concurrent.Future;
 
@@ -37,5 +40,19 @@ public interface ExportsResource {
      * @return A future to the response with all of the full account information
      */
     public Future<ApiResponse<List<AccountFull>>> getAccounts();
+
+    /**
+     * Get all of the detailed organization information for all orgs.
+     *
+     * @return A future to the response with all the organization info.
+     */
+    public Future<ApiResponse<List<OrgFull>>> getOrgs();
+
+    /**
+     * Get all of the timesheets.
+     *
+     * @return A future to the response with all of the timesheets
+     */
+    public Future<ApiResponse<List<Timesheet>>> getTimesheets();
 
 }

--- a/src/main/java/com/orgsync/api/ExportsResource.java
+++ b/src/main/java/com/orgsync/api/ExportsResource.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 OrgSync
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.orgsync.api;
+
+import com.orgsync.api.model.accounts.AccountFull;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+/**
+ * <p>
+ * Access to data exports from the API, which provide a convienient way to request large amounts of data
+ * in a single call.  The drawback is that these requests can take a significant amount of time.
+ * </p>
+ * See: <a href="https://orgsync.com/36548/files/496821/show">https://orgsync.com/36548/files/496821/show</a>
+ *
+ * @author steffyj
+ */
+public interface ExportsResource {
+
+    /**
+     * Get all of the detailed account information about every account.
+     *
+     * @return A future to the response with all of the full account information
+     */
+    public Future<ApiResponse<List<AccountFull>>> getAccounts();
+
+}

--- a/src/main/java/com/orgsync/api/ExportsResourceImpl.java
+++ b/src/main/java/com/orgsync/api/ExportsResourceImpl.java
@@ -60,7 +60,7 @@ import java.util.concurrent.Future;
     }
 
     private <T> DataExportTask<T> newTask(String exportType, Type type) {
-        return new DataExportTask<T>(this, exportType, getClient().getHttpClient(), type);
+        return new DataExportTask<T>(this, exportType, getClient(), type);
     }
 
     /* package */Future<ApiResponse<ExportResponse>> requestToken(String exportType) {

--- a/src/main/java/com/orgsync/api/ExportsResourceImpl.java
+++ b/src/main/java/com/orgsync/api/ExportsResourceImpl.java
@@ -40,7 +40,7 @@ import java.util.concurrent.Future;
 
     @Override
     public Future<ApiResponse<List<AccountFull>>> getAccounts() {
-        return executor.submit(new DataExportTask<List<AccountFull>>(this, "accounts"));
+        return executor.submit(new DataExportTask<AccountFull>(this, "accounts", getClient().getHttpClient(), AccountFull.TYPE));
     }
 
     /* package */Future<ApiResponse<ExportRequest>> requestToken(String exportType) {

--- a/src/main/java/com/orgsync/api/ExportsResourceImpl.java
+++ b/src/main/java/com/orgsync/api/ExportsResourceImpl.java
@@ -15,9 +15,13 @@
 */
 package com.orgsync.api;
 
+import com.google.gson.reflect.TypeToken;
 import com.orgsync.api.model.accounts.AccountFull;
 
+import java.lang.reflect.Type;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 /**
@@ -27,13 +31,31 @@ import java.util.concurrent.Future;
  */
 /* package */class ExportsResourceImpl extends BaseResource implements ExportsResource {
 
+    private static final ExecutorService executor = Executors.newCachedThreadPool(new NamedThreadFactory("api-exports"));
+
     /* package */ExportsResourceImpl(final ApiClientImpl client) {
         super(client, "/exports");
     }
 
     @Override
     public Future<ApiResponse<List<AccountFull>>> getAccounts() {
-        return null;
+        return executor.submit(new DataExportTask<List<AccountFull>>(this, "accounts"));
     }
 
+    /* package */Future<ApiResponse<ExportRequest>> requestToken(String exportType) {
+        String url = String.format("%s/%s", getEndpoint(), exportType);
+        return getResponse(RequestParams.get(url), ExportRequest.TYPE);
+    }
+
+    /* package */static class ExportRequest {
+
+        public static final Type TYPE = new TypeToken<ExportRequest>() {
+        }.getType();
+
+        private String exportToken;
+
+        public String getExportToken() {
+            return exportToken;
+        }
+    }
 }

--- a/src/main/java/com/orgsync/api/ExportsResourceImpl.java
+++ b/src/main/java/com/orgsync/api/ExportsResourceImpl.java
@@ -63,25 +63,25 @@ import java.util.concurrent.Future;
         return new DataExportTask<T>(this, exportType, getClient().getHttpClient(), type);
     }
 
-    /* package */Future<ApiResponse<ExportRequest>> requestToken(String exportType) {
+    /* package */Future<ApiResponse<ExportResponse>> requestToken(String exportType) {
         String url = String.format("%s/%s", getEndpoint(), exportType);
-        return getResponse(RequestParams.get(url), ExportRequest.TYPE);
+        return getResponse(RequestParams.get(url), ExportResponse.TYPE);
     }
 
-    /* package */Future<ApiResponse<RedeemRequest>> redeemToken(String token) {
+    /* package */Future<ApiResponse<RedeemResponse>> redeemToken(String token) {
         String url = getEndpoint() + "/redeem";
         FluentStringsMap params = new FluentStringsMap().add("export_token", token);
-        return getResponse(RequestParams.get(url, params), RedeemRequest.TYPE);
+        return getResponse(RequestParams.get(url, params), RedeemResponse.TYPE);
     }
 
-    /* package */static class ExportRequest {
+    /* package */static class ExportResponse {
 
-        public static final Type TYPE = new TypeToken<ExportRequest>() {
+        public static final Type TYPE = new TypeToken<ExportResponse>() {
         }.getType();
 
         private final String exportToken;
 
-        ExportRequest(String exportToken) {
+        ExportResponse(String exportToken) {
             this.exportToken = exportToken;
         }
 
@@ -90,14 +90,14 @@ import java.util.concurrent.Future;
         }
     }
 
-   /* package */static class RedeemRequest {
+   /* package */static class RedeemResponse {
 
-        public static final Type TYPE = new TypeToken<RedeemRequest>() {
+        public static final Type TYPE = new TypeToken<RedeemResponse>() {
         }.getType();
 
         private final String downloadUrl;
 
-        RedeemRequest(String downloadUrl) {
+        RedeemResponse(String downloadUrl) {
             this.downloadUrl = downloadUrl;
         }
 

--- a/src/main/java/com/orgsync/api/ExportsResourceImpl.java
+++ b/src/main/java/com/orgsync/api/ExportsResourceImpl.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 OrgSync
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.orgsync.api;
+
+import com.orgsync.api.model.accounts.AccountFull;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+/**
+ * The implementation of the exports resource.
+ *
+ * @author steffyj
+ */
+/* package */class ExportsResourceImpl extends BaseResource implements ExportsResource {
+
+    /* package */ExportsResourceImpl(final ApiClientImpl client) {
+        super(client, "/exports");
+    }
+
+    @Override
+    public Future<ApiResponse<List<AccountFull>>> getAccounts() {
+        return null;
+    }
+
+}

--- a/src/main/java/com/orgsync/api/ExportsResourceImpl.java
+++ b/src/main/java/com/orgsync/api/ExportsResourceImpl.java
@@ -18,6 +18,8 @@ package com.orgsync.api;
 import com.google.gson.reflect.TypeToken;
 import com.ning.http.client.FluentStringsMap;
 import com.orgsync.api.model.accounts.AccountFull;
+import com.orgsync.api.model.orgs.OrgFull;
+import com.orgsync.api.model.timesheets.Timesheet;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -40,7 +42,25 @@ import java.util.concurrent.Future;
 
     @Override
     public Future<ApiResponse<List<AccountFull>>> getAccounts() {
-        return executor.submit(new DataExportTask<AccountFull>(this, "accounts", getClient().getHttpClient(), AccountFull.TYPE));
+        return submitTask("accounts", AccountFull.TYPE);
+    }
+
+    @Override
+    public Future<ApiResponse<List<OrgFull>>> getOrgs() {
+        return submitTask("orgs", OrgFull.TYPE);
+    }
+
+    @Override
+    public Future<ApiResponse<List<Timesheet>>> getTimesheets() {
+        return submitTask("timesheets", Timesheet.TYPE);
+    }
+
+    private <T> Future<ApiResponse<List<T>>>submitTask(String exportType, Type type) {
+        return executor.submit(this.<T>newTask(exportType, type));
+    }
+
+    private <T> DataExportTask<T> newTask(String exportType, Type type) {
+        return new DataExportTask<T>(this, exportType, getClient().getHttpClient(), type);
     }
 
     /* package */Future<ApiResponse<ExportRequest>> requestToken(String exportType) {

--- a/src/main/java/com/orgsync/api/ExportsResourceImpl.java
+++ b/src/main/java/com/orgsync/api/ExportsResourceImpl.java
@@ -16,6 +16,7 @@
 package com.orgsync.api;
 
 import com.google.gson.reflect.TypeToken;
+import com.ning.http.client.FluentStringsMap;
 import com.orgsync.api.model.accounts.AccountFull;
 
 import java.lang.reflect.Type;
@@ -47,6 +48,12 @@ import java.util.concurrent.Future;
         return getResponse(RequestParams.get(url), ExportRequest.TYPE);
     }
 
+    /* package */Future<ApiResponse<RedeemRequest>> redeemToken(String token) {
+        String url = getEndpoint() + "/redeem";
+        FluentStringsMap params = new FluentStringsMap().add("export_token", token);
+        return getResponse(RequestParams.get(url, params), RedeemRequest.TYPE);
+    }
+
     /* package */static class ExportRequest {
 
         public static final Type TYPE = new TypeToken<ExportRequest>() {
@@ -60,6 +67,22 @@ import java.util.concurrent.Future;
 
         public String getExportToken() {
             return exportToken;
+        }
+    }
+
+   /* package */static class RedeemRequest {
+
+        public static final Type TYPE = new TypeToken<RedeemRequest>() {
+        }.getType();
+
+        private final String downloadUrl;
+
+        RedeemRequest(String downloadUrl) {
+            this.downloadUrl = downloadUrl;
+        }
+
+        public String getDownloadUrl() {
+            return downloadUrl;
         }
     }
 }

--- a/src/main/java/com/orgsync/api/ExportsResourceImpl.java
+++ b/src/main/java/com/orgsync/api/ExportsResourceImpl.java
@@ -52,7 +52,11 @@ import java.util.concurrent.Future;
         public static final Type TYPE = new TypeToken<ExportRequest>() {
         }.getType();
 
-        private String exportToken;
+        private final String exportToken;
+
+        ExportRequest(String exportToken) {
+            this.exportToken = exportToken;
+        }
 
         public String getExportToken() {
             return exportToken;

--- a/src/main/java/com/orgsync/api/MapFunction.java
+++ b/src/main/java/com/orgsync/api/MapFunction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014 OrgSync
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.orgsync.api;
+
+/**
+ * @author steffyj
+ */
+/* package */ interface MapFunction<T, S> {
+    public S f(T t) throws Exception;
+}

--- a/src/main/java/com/orgsync/api/NamedThreadFactory.java
+++ b/src/main/java/com/orgsync/api/NamedThreadFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 OrgSync
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.orgsync.api;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Create threads with a name...  Roll my own so I don't have to include a library.
+ *
+ * @author steffyj
+ */
+/* package */class NamedThreadFactory implements ThreadFactory {
+
+    private final String namePrefix;
+    private final AtomicLong counter = new AtomicLong(0);
+
+    /* package */NamedThreadFactory(String namePrefix) {
+        this.namePrefix = namePrefix;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        String name = String.format("%s-%d", namePrefix, counter.incrementAndGet());
+        return new Thread(r, name);
+    }
+}

--- a/src/main/java/com/orgsync/api/OrgSync.java
+++ b/src/main/java/com/orgsync/api/OrgSync.java
@@ -15,6 +15,8 @@
  */
 package com.orgsync.api;
 
+import java.util.Properties;
+
 /**
  * <p>
  * The entry point for creating clients for the OrgSync API V2. Static factory method are available to retrieve
@@ -56,7 +58,22 @@ public final class OrgSync {
      * @return the api client
      */
     public static ApiClient newApiClient(final String apiKey, final String host) {
-        return new ApiClientImpl(apiKey, host);
+        return new ApiClientImpl(apiKey, host, new Properties());
     }
 
+    /**
+     * Create a new V2 API client with the given OrgSync API key, host, and properties.  Most clients will not need to
+     * change these values from the default.
+     *
+     * @param apiKey
+     *            the api key for your community
+     * @param host
+     *            the host to connect to
+     * @param props
+     *            the configuration properties
+     * @return the api client
+     */
+    public static ApiClient newApiClient(final String apiKey, final String host, final Properties props) {
+        return new ApiClientImpl(apiKey, host, props);
+    }
 }

--- a/src/main/java/com/orgsync/api/Resources.java
+++ b/src/main/java/com/orgsync/api/Resources.java
@@ -89,6 +89,18 @@ public final class Resources {
     };
 
     /**
+     * The exports resource.
+     * <p>
+     * See <a href="https://orgsync.com/36548/files/496821/show">https://orgsync.com/36548/files/496821/show</a>
+     */
+    public static final Resource<ExportsResource> EXPORTS = new Resource<ExportsResource>() {
+        @Override
+        ExportsResource get(final ApiClientImpl client) {
+            return new ExportsResourceImpl(client);
+        }
+    };
+
+    /**
      * The forms resource.
      * <p>
      * See <a href="https://api.orgsync.com/api/docs/v2/forms">https://api.orgsync.com/api/docs/v2/forms</a>

--- a/src/test/java/com/orgsync/api/ApiClientImplTest.java
+++ b/src/test/java/com/orgsync/api/ApiClientImplTest.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 
 import org.junit.Before;
@@ -54,7 +55,7 @@ public class ApiClientImplTest {
     @Before
     public void setup() {
         http = mock(AsyncHttpClient.class);
-        client = new ApiClientImpl(apiKey, host).setHttpClient(http);
+        client = new ApiClientImpl(apiKey, host, new Properties()).setHttpClient(http);
     }
 
     @Test

--- a/src/test/java/com/orgsync/api/DataExportTaskTest.java
+++ b/src/test/java/com/orgsync/api/DataExportTaskTest.java
@@ -36,7 +36,7 @@ public class DataExportTaskTest {
 
     @Test
     public void testRedeemTokenFails() throws Exception {
-        ApiResponse<ExportsResourceImpl.ExportRequest> response = ApiResponseFactory.error(new ApiError("failed"));
+        ApiResponse<ExportsResourceImpl.ExportRequest> response = ApiResponseFactory.error(500, new ApiError("failed"));
         when(exports.requestToken(exportType))
                 .thenReturn(new CompletedFuture<ApiResponse<ExportsResourceImpl.ExportRequest>>(response));
 

--- a/src/test/java/com/orgsync/api/DataExportTaskTest.java
+++ b/src/test/java/com/orgsync/api/DataExportTaskTest.java
@@ -16,9 +16,6 @@
 package com.orgsync.api;
 
 import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.ListenableFuture;
-import com.ning.http.client.RequestBuilder;
-import com.ning.http.client.Response;
 import com.orgsync.api.model.ApiError;
 import com.orgsync.api.model.accounts.AccountFull;
 import org.junit.Test;
@@ -59,7 +56,7 @@ public class DataExportTaskTest {
 
     @Test
     public void testRequestTokenFails() throws Exception {
-        ApiResponse<ExportsResourceImpl.ExportRequest> response = ApiResponseFactory.error(500, new ApiError("failed"));
+        ApiResponse<ExportsResourceImpl.ExportResponse> response = ApiResponseFactory.error(500, new ApiError("failed"));
         setRequestToken(response);
 
         assertEquals(response, task.call());
@@ -67,8 +64,8 @@ public class DataExportTaskTest {
 
     @Test
     public void testExportInProgress() throws Exception {
-        ExportsResourceImpl.ExportRequest result = new ExportsResourceImpl.ExportRequest("abc123");
-        ApiResponse<ExportsResourceImpl.ExportRequest> response = ApiResponseFactory.success(202, result);
+        ExportsResourceImpl.ExportResponse result = new ExportsResourceImpl.ExportResponse("abc123");
+        ApiResponse<ExportsResourceImpl.ExportResponse> response = ApiResponseFactory.success(202, result);
         setRequestToken(response);
 
         assertEquals(ApiResponseFactory.error(202, new ApiError("Export already in progress!")), task.call());
@@ -100,9 +97,9 @@ public class DataExportTaskTest {
         setSuccessfulToken();
 
         String url = "http://some.local/url";
-        ExportsResourceImpl.RedeemRequest response = new ExportsResourceImpl.RedeemRequest(url);
+        ExportsResourceImpl.RedeemResponse response = new ExportsResourceImpl.RedeemResponse(url);
         setRedeemToken(true, 202, null)
-                .thenReturn(new CompletedFuture<ApiResponse<ExportsResourceImpl.RedeemRequest>>(ApiResponseFactory.success(200, response)));
+                .thenReturn(new CompletedFuture<ApiResponse<ExportsResourceImpl.RedeemResponse>>(ApiResponseFactory.success(200, response)));
 
         task.call();
 
@@ -121,14 +118,14 @@ public class DataExportTaskTest {
         assertEquals(ApiResponseFactory.error(500, "Exception caught: " + message), task.call());
     }
 
-    private void setRequestToken(ApiResponse<ExportsResourceImpl.ExportRequest> response) {
+    private void setRequestToken(ApiResponse<ExportsResourceImpl.ExportResponse> response) {
         when(exports.requestToken(exportType))
-                .thenReturn(new CompletedFuture<ApiResponse<ExportsResourceImpl.ExportRequest>>(response));
+                .thenReturn(new CompletedFuture<ApiResponse<ExportsResourceImpl.ExportResponse>>(response));
     }
 
-    private OngoingStubbing<Future<ApiResponse<ExportsResourceImpl.RedeemRequest>>> setRedeemToken(boolean success, int status, String urlOrMessage) {
-        ExportsResourceImpl.RedeemRequest result = new ExportsResourceImpl.RedeemRequest(urlOrMessage);
-        ApiResponse<ExportsResourceImpl.RedeemRequest> response = null;
+    private OngoingStubbing<Future<ApiResponse<ExportsResourceImpl.RedeemResponse>>> setRedeemToken(boolean success, int status, String urlOrMessage) {
+        ExportsResourceImpl.RedeemResponse result = new ExportsResourceImpl.RedeemResponse(urlOrMessage);
+        ApiResponse<ExportsResourceImpl.RedeemResponse> response = null;
         if (success) {
             response = ApiResponseFactory.success(status, result);
         } else {
@@ -136,12 +133,12 @@ public class DataExportTaskTest {
         }
 
         return when(exports.redeemToken(exportToken))
-                .thenReturn(new CompletedFuture<ApiResponse<ExportsResourceImpl.RedeemRequest>>(response));
+                .thenReturn(new CompletedFuture<ApiResponse<ExportsResourceImpl.RedeemResponse>>(response));
     }
 
     private void setSuccessfulToken() {
-        ExportsResourceImpl.ExportRequest result = new ExportsResourceImpl.ExportRequest(exportToken);
-        ApiResponse<ExportsResourceImpl.ExportRequest> response = ApiResponseFactory.success(200, result);
+        ExportsResourceImpl.ExportResponse result = new ExportsResourceImpl.ExportResponse(exportToken);
+        ApiResponse<ExportsResourceImpl.ExportResponse> response = ApiResponseFactory.success(200, result);
         setRequestToken(response);
     }
 

--- a/src/test/java/com/orgsync/api/DataExportTaskTest.java
+++ b/src/test/java/com/orgsync/api/DataExportTaskTest.java
@@ -43,6 +43,16 @@ public class DataExportTaskTest {
         assertEquals(response, task.call());
     }
 
+    @Test
+    public void testExportInProgress() throws Exception {
+        ExportsResourceImpl.ExportRequest result = new ExportsResourceImpl.ExportRequest("abc123");
+        ApiResponse<ExportsResourceImpl.ExportRequest> response = ApiResponseFactory.success(202, result);
+        when(exports.requestToken(exportType))
+                .thenReturn(new CompletedFuture<ApiResponse<ExportsResourceImpl.ExportRequest>>(response));
+
+        assertEquals(ApiResponseFactory.error(202, new ApiError("Export already in progress!")), task.call());
+    }
+
     static final class CompletedFuture<T> implements Future<T> {
 
         private final T value;

--- a/src/test/java/com/orgsync/api/DataExportTaskTest.java
+++ b/src/test/java/com/orgsync/api/DataExportTaskTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 OrgSync
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.orgsync.api;
+
+import com.orgsync.api.model.ApiError;
+import org.junit.Test;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+/**
+ * @author steffyj
+ */
+public class DataExportTaskTest {
+
+    private final ExportsResourceImpl exports = mock(ExportsResourceImpl.class);
+    private final String exportType = "test";
+
+    private final DataExportTask task = new DataExportTask(exports, exportType);
+
+    @Test
+    public void testRedeemTokenFails() throws Exception {
+        ApiResponse<ExportsResourceImpl.ExportRequest> response = ApiResponseFactory.error(new ApiError("failed"));
+        when(exports.requestToken(exportType))
+                .thenReturn(new CompletedFuture<ApiResponse<ExportsResourceImpl.ExportRequest>>(response));
+
+        assertEquals(response, task.call());
+    }
+
+    static final class CompletedFuture<T> implements Future<T> {
+
+        private final T value;
+
+        CompletedFuture(final T value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean isDone() {
+            return true;
+        }
+
+        @Override
+        public T get() {
+            return value;
+        }
+
+        @Override
+        public T get(final long timeout, final TimeUnit unit) {
+            return value;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public boolean cancel(final boolean mayInterruptIfRunning) {
+            return false;
+        }
+    }
+
+
+}

--- a/src/test/java/com/orgsync/api/DataExportTaskTest.java
+++ b/src/test/java/com/orgsync/api/DataExportTaskTest.java
@@ -18,6 +18,7 @@ package com.orgsync.api;
 import com.ning.http.client.AsyncHttpClient;
 import com.orgsync.api.model.ApiError;
 import com.orgsync.api.model.accounts.AccountFull;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.stubbing.OngoingStubbing;
 
@@ -34,7 +35,8 @@ import static org.junit.Assert.*;
 public class DataExportTaskTest {
 
     private final ExportsResourceImpl exports = mock(ExportsResourceImpl.class);
-    private final AsyncHttpClient client = mock(AsyncHttpClient.class);
+    private final ApiClientImpl client = mock(ApiClientImpl.class);
+    private final AsyncHttpClient httpClient = mock(AsyncHttpClient.class);
     private final String exportType = "test";
     private final String exportToken = "abc123";
     private final Type type = AccountFull.TYPE;
@@ -53,6 +55,11 @@ public class DataExportTaskTest {
     };
 
     private final DataExportTaskTester task = new DataExportTaskTester(exports, exportType, type);
+
+    @Before
+    public void initClient() {
+        when(client.getHttpClient()).thenReturn(httpClient);
+    }
 
     @Test
     public void testRequestTokenFails() throws Exception {
@@ -113,7 +120,7 @@ public class DataExportTaskTest {
         String message = "fail on download";
         setRedeemToken(true, 200, url);
 
-        when(client.prepareGet(url)).thenThrow(new RuntimeException(message));
+        when(httpClient.prepareGet(url)).thenThrow(new RuntimeException(message));
 
         assertEquals(ApiResponseFactory.error(500, "Exception caught: " + message), task.call());
     }

--- a/src/test/java/com/orgsync/api/ExportsResourceImplTest.java
+++ b/src/test/java/com/orgsync/api/ExportsResourceImplTest.java
@@ -15,6 +15,7 @@
 */
 package com.orgsync.api;
 
+import com.ning.http.client.FluentStringsMap;
 import org.junit.Test;
 
 /**
@@ -30,5 +31,13 @@ public class ExportsResourceImplTest extends BaseResourceTest {
         exports.requestToken(exportType);
 
         verifyRequest(RequestParams.get("/exports/" + exportType));
+    }
+
+    @Test
+    public void testRedeemToken() {
+        String token = "something";
+        exports.redeemToken(token);
+
+        verifyRequest(RequestParams.get("/exports/redeem", new FluentStringsMap().add("export_token", token)));
     }
 }

--- a/src/test/java/com/orgsync/api/ExportsResourceImplTest.java
+++ b/src/test/java/com/orgsync/api/ExportsResourceImplTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 OrgSync
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.orgsync.api;
+
+import org.junit.Test;
+
+/**
+ * @author steffyj
+ */
+public class ExportsResourceImplTest extends BaseResourceTest {
+
+    private final ExportsResourceImpl exports = new ExportsResourceImpl(client);
+
+    @Test
+    public void testRequestToken() {
+        String exportType = "abc";
+        exports.requestToken(exportType);
+
+        verifyRequest(RequestParams.get("/exports/" + exportType));
+    }
+}


### PR DESCRIPTION
Adding support for async data exports.  Current thoughts are to keep it really simple (although slightly wasteful).  Use an `ExecutorService` in the `ExportsResourceImpl` to submit `DataExportTask`s and return those futures.

Each `Thread` will then be tied up making the request, polling for completion, downloading the file, unzipping it, and parsing the result.

closes #5 
